### PR TITLE
fix(install): remove non-existent custom fields from before_install query

### DIFF
--- a/italian_invoice/install.py
+++ b/italian_invoice/install.py
@@ -218,9 +218,10 @@ def fix_erpnext_italy_duplicate_fields():
 	print(f"Trovati {len(fields_to_migrate)} campi problematici da migrare")
 
 	# Save data from all Customers (old field names)
+	# Note: custom_first_name/custom_last_name don't exist yet (created in after_install)
 	customers_data = {}
 	customers = frappe.get_all(
-		"Customer", fields=["name", "first_name", "last_name", "custom_first_name", "custom_last_name"]
+		"Customer", fields=["name", "first_name", "last_name"]
 	)
 
 	for customer in customers:


### PR DESCRIPTION
### **User description**
## Summary

Fix installation error when ERPNext Italy regional customizations exist.

## Problem

When installing `italian_invoice` on a site with ERPNext Italy regional customizations, the installation fails with:
```
(1054, "Unknown column 'custom_first_name' in 'SELECT'")
```

## Root Cause

The `fix_erpnext_italy_duplicate_fields()` function in `before_install()` queries `custom_first_name` and `custom_last_name` fields that do not exist yet in the database. These fields are created later in `after_install()`.

## Solution

Removed the non-existent fields from the query in `before_install()`. The migration only reads fields that exist at that time (`first_name` and `last_name` from ERPNext Italy Custom Fields).

## Changes

- `install.py`: Removed `custom_first_name` and `custom_last_name` from the query in `fix_erpnext_italy_duplicate_fields()`

## Testing

Tested on clean installation with ERPNext Italy regional customizations.

Fixes #3


___

### **PR Type**
Bug fix


___

### **Description**
- Remove non-existent custom fields from before_install query

- Prevents SQL error when installing with ERPNext Italy customizations

- Query now only reads fields that exist at before_install execution time


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["before_install hook"] -->|queries Customer| B["Removed custom_first_name/custom_last_name"]
  B -->|prevents SQL error| C["Installation succeeds"]
  D["after_install hook"] -->|creates custom fields| E["Fields available later"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.py</strong><dd><code>Remove non-existent custom fields from migration query</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

italian_invoice/install.py

<ul><li>Removed <code>custom_first_name</code> and <code>custom_last_name</code> from the Customer query <br>in <code>fix_erpnext_italy_duplicate_fields()</code><br> <li> Added clarifying comment explaining these fields don't exist yet <br>during before_install<br> <li> Query now only retrieves <code>name</code>, <code>first_name</code>, and <code>last_name</code> fields that <br>exist at migration time</ul>


</details>


  </td>
  <td><a href="https://github.com/Solede-SA/italian_invoice/pull/4/files#diff-7a8ce79b52a208f3f1d7561ccc1eb292670318de1ea9e32c9fa67e00e4f07713">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

