### PR TITLE
README.md: Fix openapi setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ Perfetto per test senza dipendenze esterne:
 Per invio automatico al SDI:
 
 ```bash
-bench get-app openapi
+bench get-app https://github.com/Solede-SA/openapi.git
 bench --site [nome-sito] install-app openapi
+bench --site [nome-sito] migrate
 ```
 
 Poi imposta Provider SDI = "OpenAPI" in Company.


### PR DESCRIPTION
Testando l'integrazione con e-invoice usando OpenAPI mi sono accorto che openapi non è un modulo standard di Frappe o ERPnext. Ho corretto la documentazione.
Se serve posso estendere la pull request ai due branch version-15 e version-16.