### PR TITLE
fix(fattura_fornitori_sdi): rimuovi dipendenza hardcoded da app openapi + fallback supplier per nome

### DIFF
--- a/italian_invoice/italian_invoice/doctype/fattura_fornitori_sdi/fattura_fornitori_sdi.js
+++ b/italian_invoice/italian_invoice/doctype/fattura_fornitori_sdi/fattura_fornitori_sdi.js
@@ -15,9 +15,12 @@ frappe.ui.form.on("Fattura Fornitori SDI", {
             frm.enable_save();
         }
 
-        frm.add_custom_button(__("Scarica PDF"), () => {
-            window.location.href = `/api/method/openapi.api.sdi.fatture.download?doctype=Fattura Fornitori SDI&docname=${frm.doc.name}&type=pdf`;
-        });
+        // "Scarica PDF" disponibile solo se l'app openapi è installata (provider SDI specifico)
+        if (frappe.boot.installed_apps && frappe.boot.installed_apps.includes('openapi')) {
+            frm.add_custom_button(__("Scarica PDF"), () => {
+                window.location.href = `/api/method/openapi.api.sdi.fatture.download?doctype=Fattura Fornitori SDI&docname=${frm.doc.name}&type=pdf`;
+            });
+        }
 
         // Pulisci campo documenti aperti
         frm.get_field('documenti_aperti').$wrapper.html('');
@@ -36,10 +39,10 @@ frappe.ui.form.on("Fattura Fornitori SDI", {
 
                     // Prima verifichiamo/creiamo il fornitore
                     frappe.call({
-                        method: "openapi.api.eInvoice.purchase_invoice.get_or_create_supplier",
+                        method: "italian_invoice.utilities.fatture_passive.get_or_create_supplier",
                         args: {
                             supplier_vat_id: supplier_vat,
-                            fattura_fornitori_sdi: frm.doc.name
+                            invoice_data: frm.doc.dati_fattura
                         },
                         callback: (r) => {
                             if (!r.message.success) {
@@ -286,9 +289,9 @@ function show_items_dialog(frm, supplier_data) {
             });
 
             frappe.call({
-                method: "openapi.api.eInvoice.purchase_invoice.process_supplier_invoice",
+                method: "italian_invoice.utilities.fatture_passive.process_supplier_invoice",
                 args: {
-                    json_data_string: frm.doc.dati_fattura,
+                    invoice_data: frm.doc.dati_fattura,
                     fattura_fornitori_sdi: frm.doc.name,
                     item_mappings: item_mappings
                 },

--- a/italian_invoice/utilities/fatture_passive.py
+++ b/italian_invoice/utilities/fatture_passive.py
@@ -9,20 +9,39 @@ from difflib import SequenceMatcher
 import frappe
 
 
+@frappe.whitelist()
 def get_or_create_supplier(supplier_vat_id, invoice_data):
 	"""
 	Controlla se esiste un fornitore con la partita IVA data, altrimenti lo crea
 
 	Args:
 	    supplier_vat_id: Partita IVA del fornitore
-	    invoice_data: Dati fattura per recuperare info fornitore
+	    invoice_data: Dati fattura (dict o JSON string) per recuperare info fornitore
 
 	Returns:
 	    dict: Dati del fornitore (esistente o appena creato)
 	"""
+	if isinstance(invoice_data, str):
+		invoice_data = json.loads(invoice_data)
+
+	supplier_data = None
 	try:
-		# Cerca fornitore esistente
+		# Cerca fornitore per P.IVA
 		supplier = frappe.db.exists("Supplier", {"tax_id": supplier_vat_id})
+
+		if not supplier:
+			# Fallback: cerca per nome (potrebbe esistere un fornitore senza tax_id)
+			supplier_data = extract_supplier_data(invoice_data)
+			denominazione = (
+				supplier_data.get("dati_anagrafici", {}).get("anagrafica", {}).get("denominazione", "")
+				or supplier_data.get("dati_anagrafici", {}).get("anagrafica", {}).get("nome", "")
+			)
+			if denominazione:
+				supplier = frappe.db.exists("Supplier", {"supplier_name": denominazione})
+
+			if supplier:
+				# Trovato per nome: aggiorna la P.IVA mancante
+				frappe.db.set_value("Supplier", supplier, "tax_id", supplier_vat_id)
 
 		if supplier:
 			# Ritorna i dati del fornitore esistente
@@ -34,8 +53,9 @@ def get_or_create_supplier(supplier_vat_id, invoice_data):
 				"is_new": False,
 			}
 
-		# Estrai dati fornitore dal JSON/XML
-		supplier_data = extract_supplier_data(invoice_data)
+		# Estrai dati fornitore se non ancora fatto
+		if not supplier_data:
+			supplier_data = extract_supplier_data(invoice_data)
 
 		# Crea nuovo fornitore
 		new_supplier = create_supplier(supplier_data, invoice_data.get("company"))
@@ -49,7 +69,8 @@ def get_or_create_supplier(supplier_vat_id, invoice_data):
 		}
 
 	except Exception as e:
-		frappe.log_error(f"Errore in get_or_create_supplier: {str(e)}", "Italian Invoice Passive")
+		# Titolo del log troncato a 140 char (limite Frappe per il campo title)
+		frappe.log_error(str(e)[:140], "Italian Invoice Passive")
 		return {"success": False, "error": str(e)}
 
 


### PR DESCRIPTION
## Summary

- **Disaccoppiamento JS+Python da app `openapi`**: `fattura_fornitori_sdi.js` chiamava `openapi.api.eInvoice.purchase_invoice.*`, ma quei metodi sono già thin wrapper di delega a `italian_invoice.utilities.fatture_passive.*`. Chi non aveva l'app `openapi` installata otteneva l'errore *"L'app openapi non è installata"* su "Importa Fattura". Ora le chiamate sono dirette al modulo `italian_invoice`.
- **Bottone "Scarica PDF"** reso condizionale a `frappe.boot.installed_apps.includes('openapi')` (usa endpoint specifico del provider `openapi`, non disponibile altrove).
- **Fix duplicate Supplier (`IntegrityError 1062`)**: `get_or_create_supplier` cercava solo per `tax_id`. Fornitori inseriti manualmente senza `tax_id` ma con `supplier_name` matching causavano errore di chiave duplicata su `Supplier.name`. Aggiunto fallback per `supplier_name` con auto-update della P.IVA mancante.
- **Fix log_error title troppo lungo**: troncato a 140 char (limite del campo `title` di `Error Log` in Frappe — l'errore originale era invisibile perché il logger stesso falliva).
- **`@frappe.whitelist()`** aggiunto su `get_or_create_supplier` (ora richiamato direttamente dal JS) e parse di `invoice_data` se arriva come JSON string (frappe.call serializza i dict lato wire).

## Test plan
- [ ] Importa fattura passiva su istanza ERPNext **senza** app `openapi` installata → "Importa Fattura" funziona end-to-end
- [ ] Importa fattura passiva su istanza **con** `openapi` installata → comportamento invariato (il wrapper openapi delega ancora a `italian_invoice`, gli utenti vecchi non vedono regressioni)
- [ ] Verifica che il pulsante "Scarica PDF" appaia **solo** se `openapi` è installato
- [ ] Crea manualmente un Supplier senza `tax_id` e con stesso `supplier_name` di una fattura in arrivo → import deve riusare quel Supplier (no `IntegrityError`) e popolare automaticamente la P.IVA
- [ ] Verifica che `italian_invoice.utilities.fatture_passive.get_or_create_supplier` sia richiamabile via REST `/api/method/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)